### PR TITLE
Update policy to AWS_ConfigRole

### DIFF
--- a/lib/aws-config-packs.ts
+++ b/lib/aws-config-packs.ts
@@ -117,7 +117,7 @@ export class ConfigRecorderEnabledPromise extends cdk.Construct {
               inlinePolicies: {
                 configRecorderS3Access: iam.PolicyDocument.fromJson(recorderPolicyDoc)
               },
-              managedPolicies: [iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWSConfigRole')]
+              managedPolicies: [iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AWS_ConfigRole')]
             });    
         
             this.ConfigRecorder = new cfg.CfnConfigurationRecorder(this, 'ConfigRecorder', {


### PR DESCRIPTION
AWSConfigRole is deprecated. The replacement policy is AWS_ConfigRole.
https://docs.aws.amazon.com/config/latest/developerguide/security-iam-awsmanpol.html

*Issue #, if available:*
Policy arn:aws:iam::aws:policy/service-role/AWSConfigRole does not exist or is not attachable. (Service: AmazonIdentityManagement; Status Code: 404; Error Code: NoSuchEntity; Request ID: xxx ; Proxy: null)

*Description of changes:*
Updated policy to from AWSConfigRole to AWS_ConfigRole.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
